### PR TITLE
CLR Bridge Redesign und InterpreterOptions Interface

### DIFF
--- a/Compiler/Optimizer.cs
+++ b/Compiler/Optimizer.cs
@@ -490,22 +490,30 @@ namespace ScriptStack.Compiler
         private void OptimiseConstantConditionalJumps(int iIndex)
         {
 
-            List<Instruction> listInstructions
-                = executable.InstructionsInternal;
+            List<Instruction> listInstructions = executable.InstructionsInternal;
 
-            Instruction scriptInstruction
-                = listInstructions[iIndex];
-            if (scriptInstruction.OpCode != OpCode.JZ
-                && scriptInstruction.OpCode != OpCode.JNZ) return;
-            if (scriptInstruction.First.Type != OperandType.Literal) return;
-            if (scriptInstruction.First.Value.GetType() != typeof(bool)) return;
+            Instruction scriptInstruction = listInstructions[iIndex];
+
+            if (scriptInstruction.OpCode != OpCode.JZ && scriptInstruction.OpCode != OpCode.JNZ) 
+                return;
+
+            if (scriptInstruction.First.Type != OperandType.Literal) 
+                return;
+
+            if (scriptInstruction.First.Value.GetType() != typeof(bool)) 
+                return;
+
             bool bCondition = (bool) scriptInstruction.First.Value;
 
             InsertOptimiserInfo(iIndex, "Constant Conditional Jump");
 
             OpCode opcodeJump = scriptInstruction.OpCode;
-            if ((opcodeJump == OpCode.JZ && bCondition)
-                || (opcodeJump == OpCode.JNZ && !bCondition))
+
+            // IMPORTANT:
+            //   JZ  = "jump if condition is FALSE"  (i.e. skip block when condition is false)
+            //   JNZ = "jump if condition is TRUE"
+            // So with a constant boolean we can eliminate/replace the jump accordingly.
+            if ((opcodeJump == OpCode.JZ && !bCondition) || (opcodeJump == OpCode.JNZ && bCondition))
             {
                 scriptInstruction.OpCode = OpCode.JMP;
                 scriptInstruction.First = scriptInstruction.Second;

--- a/Manager.cs
+++ b/Manager.cs
@@ -100,7 +100,14 @@ namespace ScriptStack
                 {
                     assembly = Assembly.LoadFile(dll);
                 }
-                catch (Exception e) { Console.WriteLine($"[LoadComponents] Fehler beim Laden '{dll}': {e.Message}"); continue; }
+                catch (Exception e) { 
+                    Console.WriteLine($"[LoadComponents] Fehler beim Laden '{dll}': {e.Message}");
+
+                    if (e is TargetInvocationException tie && tie.InnerException != null)
+                        Console.WriteLine("INNER: " + tie.InnerException);
+
+                    continue; 
+                }
 
                 Type[] arrayTypes = assembly.GetExportedTypes();
 

--- a/Runtime/ArrayList.cs
+++ b/Runtime/ArrayList.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
+using System.Globalization;
 
 namespace ScriptStack.Runtime
 {
@@ -17,7 +18,7 @@ namespace ScriptStack.Runtime
             if (objectValue.GetType() != typeof(ArrayList))
                 stringBuilder.Append("\"" + objectValue + "\"");
 
-            else 
+            else
                 stringBuilder.Append(objectValue);
 
             return;
@@ -115,22 +116,157 @@ namespace ScriptStack.Runtime
 
         public override string ToString()
         {
-            string culture = Thread.CurrentThread.CurrentCulture.NumberFormat.PercentDecimalSeparator;
-            string decimalSeparator = ",";
-            //if (culture.ToString().Trim() == ",") decimalSeparator = ";";
-            StringBuilder stringBuilder = new StringBuilder();
-            stringBuilder.Append("{ ");        
-            bool bFirst = true;
-            foreach (object objectKey in Keys)
+            // We intentionally output JSON here, because ScriptStack's "string(x)" uses Convert.ToString(x)
+            // which calls ToString(). Arrays vs. objects are distinguished by their key-shape:
+            // - purely non-negative int keys => JSON array (supports sparse arrays)
+            // - otherwise => JSON object
+            var sb = new StringBuilder();
+            var stack = new HashSet<object>(ReferenceEqualityComparer.Instance);
+            WriteJsonValue(sb, this, stack);
+            return sb.ToString();
+        }
+
+        private static void WriteJsonValue(StringBuilder sb, object value, HashSet<object> stack)
+        {
+            if (value == null || value is NullReference)
             {
-                if (!bFirst) stringBuilder.Append(decimalSeparator + " ");
-                bFirst = false;
-                OutputValue(stringBuilder, objectKey);
-                stringBuilder.Append(": ");
-                OutputValue(stringBuilder, this[objectKey]);
+                sb.Append("null");
+                return;
             }
-            stringBuilder.Append(" }");
-            return stringBuilder.ToString();
+
+            if (value is ArrayList al)
+            {
+                WriteJsonArrayList(sb, al, stack);
+                return;
+            }
+
+            switch (Type.GetTypeCode(value.GetType()))
+            {
+                case TypeCode.Boolean:
+                    sb.Append(((bool)value) ? "true" : "false");
+                    return;
+                case TypeCode.String:
+                    WriteJsonString(sb, (string)value);
+                    return;
+                case TypeCode.Char:
+                    WriteJsonString(sb, value.ToString());
+                    return;
+                case TypeCode.Int16:
+                case TypeCode.Int32:
+                case TypeCode.Int64:
+                case TypeCode.UInt16:
+                case TypeCode.UInt32:
+                case TypeCode.UInt64:
+                case TypeCode.Single:
+                case TypeCode.Double:
+                case TypeCode.Decimal:
+                case TypeCode.SByte:
+                case TypeCode.Byte:
+                    // JSON numbers must be culture-invariant.
+                    sb.Append(Convert.ToString(value, CultureInfo.InvariantCulture));
+                    return;
+                case TypeCode.DateTime:
+                    // No dedicated JSON date type: emit as ISO-8601 string.
+                    WriteJsonString(sb, ((DateTime)value).ToString("O", CultureInfo.InvariantCulture));
+                    return;
+                default:
+                    // Fallback: emit as string.
+                    WriteJsonString(sb, value.ToString());
+                    return;
+            }
+        }
+
+        private static void WriteJsonArrayList(StringBuilder sb, ArrayList al, HashSet<object> stack)
+        {
+            if (!stack.Add(al))
+            {
+                // Cyclic structure: represent as null to avoid infinite recursion.
+                sb.Append("null");
+                return;
+            }
+
+            // Detect "array" shape: all keys are non-negative int.
+            bool allIntKeys = true;
+            int maxIndex = -1;
+            foreach (var k in al.Keys)
+            {
+                if (k is int i && i >= 0)
+                {
+                    if (i > maxIndex) maxIndex = i;
+                    continue;
+                }
+
+                allIntKeys = false;
+                break;
+            }
+
+            if (allIntKeys)
+            {
+                sb.Append('[');
+                for (int i = 0; i <= maxIndex; i++)
+                {
+                    if (i > 0) sb.Append(',');
+                    if (al.TryGetValue(i, out var v))
+                        WriteJsonValue(sb, v, stack);
+                    else
+                        sb.Append("null");
+                }
+                sb.Append(']');
+            }
+            else
+            {
+                sb.Append('{');
+                bool first = true;
+                foreach (var kv in al)
+                {
+                    if (!first) sb.Append(',');
+                    first = false;
+                    WriteJsonString(sb, kv.Key?.ToString() ?? "null");
+                    sb.Append(':');
+                    WriteJsonValue(sb, kv.Value, stack);
+                }
+                sb.Append('}');
+            }
+
+            stack.Remove(al);
+        }
+
+        private static void WriteJsonString(StringBuilder sb, string s)
+        {
+            sb.Append('"');
+            if (s != null)
+            {
+                foreach (char c in s)
+                {
+                    switch (c)
+                    {
+                        case '"': sb.Append("\\\""); break;
+                        case '\\': sb.Append("\\\\"); break;
+                        case '\b': sb.Append("\\b"); break;
+                        case '\f': sb.Append("\\f"); break;
+                        case '\n': sb.Append("\\n"); break;
+                        case '\r': sb.Append("\\r"); break;
+                        case '\t': sb.Append("\\t"); break;
+                        default:
+                            if (c < 0x20)
+                                sb.Append("\\u" + ((int)c).ToString("x4"));
+                            else
+                                sb.Append(c);
+                            break;
+                    }
+                }
+            }
+            sb.Append('"');
+        }
+
+        /// <summary>
+        /// Reference equality comparer for cycle detection.
+        /// </summary>
+        private sealed class ReferenceEqualityComparer : IEqualityComparer<object>
+        {
+            public static readonly ReferenceEqualityComparer Instance = new ReferenceEqualityComparer();
+            public new bool Equals(object x, object y) => ReferenceEquals(x, y);
+            public int GetHashCode(object obj) => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
         }
 
         #endregion

--- a/Runtime/ClrBridge.cs
+++ b/Runtime/ClrBridge.cs
@@ -1,0 +1,634 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+
+namespace ScriptStack.Runtime
+{
+    /// <summary>
+    /// Centralized CLR interop bridge for ScriptStack.
+    /// Handles reflection-based member access, method invocation, indexers, and value coercion.
+    /// 
+    /// All access is mediated by an <see cref="IClrPolicy"/>.
+    /// </summary>
+    public sealed class ClrBridge
+    {
+
+        private readonly IClrPolicy _policy;
+
+        private static readonly BindingFlags ClrMemberFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase;
+
+        public ClrBridge(IClrPolicy policy)
+        {
+            _policy = policy ?? new DenyAllClrPolicy();
+        }
+
+        internal static object? ScriptNullToClr(object? v) => v is NullReference ? null : v;
+
+        private static object ClrNullToScript(object? v) => v ?? NullReference.Instance;
+
+        private void EnsureTypeAllowed(Type t)
+        {
+            if (!_policy.IsTypeAllowed(t))
+                throw new ExecutionException($"CLR interop is disabled or access denied for type '{t.FullName}'.");
+        }
+
+        private void EnsureReturnAllowed(object? value, string context)
+        {
+            if (!_policy.IsReturnValueAllowed(value))
+                throw new ExecutionException($"CLR interop blocked return value in {context} (type '{value?.GetType().FullName ?? "null"}').");
+        }
+
+        public object GetMember(object target, string memberName) => GetMemberValue(target, memberName);
+        public void SetMember(object target, string memberName, object scriptValue) => SetMemberValue(target, memberName, scriptValue);
+        public bool TryGetIndex(object target, object scriptKey, out object value) => TryGetIndexedValue(target, scriptKey, out value);
+        public bool TrySetIndex(object target, object scriptKey, object scriptValue) => TrySetIndexedValue(target, scriptKey, scriptValue);
+        public object Invoke(object target, string methodName, List<object> args) => InvokeMethod(target, methodName, args);
+
+        // ------------------------
+        // Coercion / Converters
+        // ------------------------
+
+        private static object CoerceTo(object value, Type targetType)
+        {
+            value = ScriptNullToClr(value);
+
+            // Handle Nullable<T>
+            var underlyingNullable = Nullable.GetUnderlyingType(targetType);
+            if (underlyingNullable != null)
+                targetType = underlyingNullable;
+
+            if (value == null)
+            {
+                // null für ValueTypes nicht erlaubt -> Default
+                return targetType.IsValueType ? Activator.CreateInstance(targetType)! : null!;
+            }
+
+            var srcType = value.GetType();
+            if (targetType.IsAssignableFrom(srcType))
+                return value;
+
+            // --- ScriptStack ArrayList -> CLR types ---
+            if (value is ArrayList scriptArr)
+            {
+                // CLR Array (e.g. int[])
+                if (targetType.IsArray)
+                {
+                    var elemType = targetType.GetElementType()!;
+                    return ConvertScriptArrayListToClrArray(scriptArr, elemType);
+                }
+
+                // Generic collections (List<T>, ICollection<T>, IEnumerable<T>, etc.)
+                if (TryConvertScriptArrayListToGenericCollection(scriptArr, targetType, out var coll))
+                    return coll;
+
+                // Generic dictionaries (Dictionary<TKey,TValue>, IDictionary<TKey,TValue>)
+                if (TryConvertScriptArrayListToGenericDictionary(scriptArr, targetType, out var dict))
+                    return dict;
+            }
+
+            // Enum conversions
+            if (targetType.IsEnum)
+                return Enum.Parse(targetType, value.ToString()!, ignoreCase: true);
+
+            // numeric / string conversions etc.
+            if (value is IConvertible)
+                return Convert.ChangeType(value, targetType, CultureInfo.InvariantCulture);
+
+            // last resort: keep as-is (Reflection may still accept via implicit operators)
+            return value;
+        }
+
+        private static object ConvertScriptArrayListToClrArray(ArrayList scriptArr, Type elementType)
+        {
+            // We only support list-like arrays here: integer keys, 0..n-1 (no gaps).
+            // Anything associative should be mapped to dictionaries instead.
+            if (scriptArr.Count == 0)
+                return Array.CreateInstance(elementType, 0);
+
+            // ensure all keys are ints
+            var keys = new List<int>(scriptArr.Count);
+            foreach (var k in scriptArr.Keys)
+            {
+                if (k is int i)
+                    keys.Add(i);
+                else
+                    throw new ExecutionException($"Associatives Array kann nicht zu '{elementType.Name}[]' konvertiert werden (Key-Typ: {k?.GetType().Name ?? "null"}).");
+            }
+
+            keys.Sort();
+            for (int i = 0; i < keys.Count; i++)
+            {
+                if (keys[i] != i)
+                    throw new ExecutionException($"Array kann nicht zu '{elementType.Name}[]' konvertiert werden: Keys müssen 0..n-1 ohne Lücken sein.");
+            }
+
+            var arr = Array.CreateInstance(elementType, keys.Count);
+            for (int i = 0; i < keys.Count; i++)
+            {
+                var v = scriptArr[i]; // uses our indexer: returns NullReference.Instance if missing
+                var coerced = CoerceTo(v, elementType);
+                arr.SetValue(coerced, i);
+            }
+            return arr;
+        }
+
+        private static Type? GetGenericInterface(Type type, Type genericDefinition)
+        {
+            if (type.IsInterface && type.IsGenericType && type.GetGenericTypeDefinition() == genericDefinition)
+                return type;
+
+            return type.GetInterfaces()
+                .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == genericDefinition);
+        }
+
+        private static bool TryConvertScriptArrayListToGenericCollection(ArrayList scriptArr, Type targetType, out object? collection)
+        {
+            collection = null;
+
+            var iface = GetGenericInterface(targetType, typeof(ICollection<>))
+                     ?? GetGenericInterface(targetType, typeof(IList<>))
+                     ?? GetGenericInterface(targetType, typeof(IEnumerable<>))
+                     ?? GetGenericInterface(targetType, typeof(IReadOnlyCollection<>))
+                     ?? GetGenericInterface(targetType, typeof(IReadOnlyList<>));
+
+            if (iface == null)
+                return false;
+
+            var elemType = iface.GetGenericArguments()[0];
+
+            // Choose concrete type
+            Type concrete = targetType;
+            if (targetType.IsInterface || targetType.IsAbstract)
+                concrete = typeof(List<>).MakeGenericType(elemType);
+
+            object instance;
+            try
+            {
+                instance = Activator.CreateInstance(concrete)!;
+            }
+            catch
+            {
+                // If the target type is non-instantiable, fallback to List<T>
+                instance = Activator.CreateInstance(typeof(List<>).MakeGenericType(elemType))!;
+                concrete = instance.GetType();
+            }
+
+            // Find Add(T)
+            var add = concrete.GetMethod("Add", new[] { elemType })
+                   ?? concrete.GetMethods().FirstOrDefault(m => m.Name == "Add" && m.GetParameters().Length == 1);
+
+            if (add == null)
+                return false;
+
+            // Add items in key order (int keys). If there are non-int keys, refuse.
+            var intKeys = new List<int>();
+            foreach (var k in scriptArr.Keys)
+            {
+                if (k is int i) intKeys.Add(i);
+                else return false;
+            }
+            intKeys.Sort();
+
+            foreach (var k in intKeys)
+            {
+                var v = scriptArr[k];
+                var coerced = CoerceTo(v, elemType);
+                add.Invoke(instance, new[] { coerced });
+            }
+
+            collection = instance;
+            return true;
+        }
+
+        private static bool TryConvertScriptArrayListToGenericDictionary(ArrayList scriptArr, Type targetType, out object? dict)
+        {
+            dict = null;
+
+            var iface = GetGenericInterface(targetType, typeof(IDictionary<,>));
+            if (iface == null)
+                return false;
+
+            var ga = iface.GetGenericArguments();
+            var keyType = ga[0];
+            var valType = ga[1];
+
+            Type concrete = targetType;
+            if (targetType.IsInterface || targetType.IsAbstract)
+                concrete = typeof(Dictionary<,>).MakeGenericType(keyType, valType);
+
+            object instance;
+            try
+            {
+                instance = Activator.CreateInstance(concrete)!;
+            }
+            catch
+            {
+                instance = Activator.CreateInstance(typeof(Dictionary<,>).MakeGenericType(keyType, valType))!;
+                concrete = instance.GetType();
+            }
+
+            var add = concrete.GetMethod("Add", new[] { keyType, valType })
+                   ?? concrete.GetMethods().FirstOrDefault(m => m.Name == "Add" && m.GetParameters().Length == 2);
+
+            if (add == null)
+                return false;
+
+            foreach (var k in scriptArr.Keys)
+            {
+                var v = scriptArr[k];
+                var ck = CoerceTo(k, keyType);
+                var cv = CoerceTo(v, valType);
+                add.Invoke(instance, new[] { ck, cv });
+            }
+
+            dict = instance;
+            return true;
+        }
+
+        private static bool TryCoerceTo(object value, Type targetType, out object? coerced)
+        {
+            try
+            {
+                coerced = CoerceTo(value, targetType);
+                return true;
+            }
+            catch
+            {
+                coerced = null;
+                return false;
+            }
+        }
+
+        // ------------------------
+        // Member get/set
+        // ------------------------
+
+        private object GetMemberValue(object target, string memberName)
+        {
+            if (target == null || target is NullReference)
+                return NullReference.Instance;
+
+            var t = target.GetType();
+            EnsureTypeAllowed(t);
+
+            // 1) Field
+            var field = t.GetField(memberName, ClrMemberFlags);
+            if (field != null)
+            {
+                if (!_policy.IsMemberAllowed(field))
+                    throw new ExecutionException($"CLR member access denied: '{t.FullName}.{field.Name}'.");
+
+                var v = field.GetValue(target);
+                EnsureReturnAllowed(v, $"field '{t.FullName}.{field.Name}'");
+                return ClrNullToScript(v);
+            }
+
+            // 2) Property
+            var prop = t.GetProperty(memberName, ClrMemberFlags);
+            if (prop != null && prop.CanRead)
+            {
+                if (!_policy.IsMemberAllowed(prop))
+                    throw new ExecutionException($"CLR member access denied: '{t.FullName}.{prop.Name}'.");
+
+                var v = prop.GetValue(target);
+                EnsureReturnAllowed(v, $"property '{t.FullName}.{prop.Name}'");
+                return ClrNullToScript(v);
+            }
+
+            return NullReference.Instance;
+        }
+
+        private void SetMemberValue(object target, string memberName, object scriptValue)
+        {
+            if (target == null || target is NullReference)
+                throw new ExecutionException($"Null reference bei Zuweisung auf Member '{memberName}'.");
+
+            var t = target.GetType();
+            EnsureTypeAllowed(t);
+
+            var field = t.GetField(memberName, ClrMemberFlags);
+            if (field != null)
+            {
+                if (!_policy.IsMemberAllowed(field))
+                    throw new ExecutionException($"CLR member write denied: '{t.FullName}.{field.Name}'.");
+
+                var coerced = CoerceTo(scriptValue, field.FieldType);
+                field.SetValue(target, coerced);
+                return;
+            }
+
+            var prop = t.GetProperty(memberName, ClrMemberFlags);
+            if (prop != null && prop.CanWrite)
+            {
+                if (!_policy.IsMemberAllowed(prop))
+                    throw new ExecutionException($"CLR member write denied: '{t.FullName}.{prop.Name}'.");
+
+                var coerced = CoerceTo(scriptValue, prop.PropertyType);
+                prop.SetValue(target, coerced);
+                return;
+            }
+
+            throw new ExecutionException($"Member '{memberName}' nicht gefunden oder nicht schreibbar auf Typ '{t.FullName}'.");
+        }
+
+        // ------------------------
+        // Method invocation
+        // ------------------------
+
+        private object InvokeMethod(object target, string methodName, List<object> args)
+        {
+            if (target == null || target is NullReference)
+                return NullReference.Instance;
+
+            var t = target.GetType();
+            EnsureTypeAllowed(t);
+
+            var methods = t.GetMethods(ClrMemberFlags);
+
+            MethodInfo? best = null;
+            object[]? bestArgs = null;
+            int bestScore = int.MaxValue;
+
+            bool anyNameMatch = false;
+            bool anyAllowedCandidate = false;
+
+            foreach (var m in methods)
+            {
+                if (!string.Equals(m.Name, methodName, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                anyNameMatch = true;
+
+                if (!_policy.IsCallAllowed(m))
+                    continue;
+
+                anyAllowedCandidate = true;
+
+                var ps = m.GetParameters();
+                if (ps.Length != args.Count)
+                    continue;
+
+                int score = 0;
+                var coercedArgs = new object[ps.Length];
+                bool ok = true;
+
+                for (int i = 0; i < ps.Length; i++)
+                {
+                    var pType = ps[i].ParameterType;
+                    var a = ScriptNullToClr(args[i]);
+
+                    if (a == null)
+                    {
+                        // null passt auf RefTypes/Nullable
+                        if (pType.IsValueType && Nullable.GetUnderlyingType(pType) == null)
+                        {
+                            ok = false;
+                            break;
+                        }
+
+                        coercedArgs[i] = null!;
+                        score += 1;
+                        continue;
+                    }
+
+                    var aType = a.GetType();
+
+                    if (pType.IsAssignableFrom(aType))
+                    {
+                        coercedArgs[i] = a;
+                        score += (pType == aType) ? 0 : 1;
+                        continue;
+                    }
+
+                    if (TryCoerceTo(a, pType, out var c) && c != null)
+                    {
+                        coercedArgs[i] = c;
+                        score += 2;
+                        continue;
+                    }
+
+                    ok = false;
+                    break;
+                }
+
+                if (!ok)
+                    continue;
+
+                if (score < bestScore)
+                {
+                    bestScore = score;
+                    best = m;
+                    bestArgs = coercedArgs;
+                }
+            }
+
+            if (best == null)
+            {
+                if (anyNameMatch && !anyAllowedCandidate)
+                    throw new ExecutionException($"CLR method call denied: '{t.FullName}.{methodName}(...)'.");
+
+                throw new ExecutionException($"Methode '{methodName}' mit {args.Count} Parametern nicht gefunden auf Typ '{t.FullName}'.");
+            }
+
+            try
+            {
+                object? result = best.Invoke(target, bestArgs);
+                if (best.ReturnType == typeof(void))
+                    return NullReference.Instance;
+
+                EnsureReturnAllowed(result, $"method '{t.FullName}.{best.Name}'");
+                return ClrNullToScript(result);
+            }
+            catch (TargetInvocationException tie)
+            {
+                // unwrap inner exception for better diagnostics
+                throw new ExecutionException($"Fehler in CLR-Methode '{t.FullName}.{best.Name}': {tie.InnerException?.Message ?? tie.Message}");
+            }
+            catch (Exception ex)
+            {
+                throw new ExecutionException($"Fehler beim Aufruf von CLR-Methode '{t.FullName}.{best.Name}': {ex.Message}");
+            }
+        }
+
+        // ------------------------
+        // Index get/set
+        // ------------------------
+
+        private bool TryGetIndexedValue(object target, object scriptKey, out object value)
+        {
+            value = NullReference.Instance;
+
+            if (target == null || target is NullReference)
+                return true;
+
+            var t = target.GetType();
+            EnsureTypeAllowed(t);
+
+            // IList / arrays
+            if (target is IList list)
+            {
+                var idxObj = ScriptNullToClr(scriptKey);
+                if (idxObj is int idx)
+                {
+                    var v = list[idx];
+                    EnsureReturnAllowed(v, $"index get '{t.FullName}[{idx}]'");
+                    value = ClrNullToScript(v);
+                    return true;
+                }
+
+                return false;
+            }
+
+            // IDictionary
+            if (target is IDictionary dict)
+            {
+                object? key = ScriptNullToClr(scriptKey);
+
+                // Try to coerce key to generic TKey if possible (avoids InvalidCastException)
+                var keyType = target.GetType().GetInterfaces()
+                    .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>))
+                    ?.GetGenericArguments()[0];
+
+                if (keyType != null && key != null && TryCoerceTo(key, keyType, out var ck) && ck != null)
+                    key = ck;
+
+                try
+                {
+                    var v = dict[key!];
+                    EnsureReturnAllowed(v, $"dictionary get '{t.FullName}[key]'");
+                    value = ClrNullToScript(v);
+                    return true;
+                }
+                catch
+                {
+                    // fall through to indexer reflection
+                }
+            }
+
+            // indexer property (Item[...])
+            foreach (var p in t.GetProperties(ClrMemberFlags))
+            {
+                var ip = p.GetIndexParameters();
+                if (ip.Length != 1 || !p.CanRead)
+                    continue;
+
+                if (!_policy.IsMemberAllowed(p))
+                    continue;
+
+                if (!TryCoerceTo(scriptKey, ip[0].ParameterType, out var ck))
+                    continue;
+
+                try
+                {
+                    var v = p.GetValue(target, new object[] { ck });
+                    EnsureReturnAllowed(v, $"indexer get '{t.FullName}.{p.Name}[...]' ");
+                    value = ClrNullToScript(v);
+                    return true;
+                }
+                catch
+                {
+                    // try next
+                }
+            }
+
+            return false;
+        }
+
+        private bool TrySetIndexedValue(object target, object scriptKey, object scriptValue)
+        {
+            if (target == null || target is NullReference)
+                return false;
+
+            var t = target.GetType();
+            EnsureTypeAllowed(t);
+
+            // IList / arrays
+            if (target is IList list)
+            {
+                var idxObj = ScriptNullToClr(scriptKey);
+                if (idxObj is not int idx)
+                    return false;
+
+                // try to coerce value to element type if we can infer it
+                Type? elemType = null;
+                var tt = target.GetType();
+                if (tt.IsArray)
+                    elemType = tt.GetElementType();
+                else
+                {
+                    var gi = tt.GetInterfaces().FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IList<>));
+                    if (gi != null) elemType = gi.GetGenericArguments()[0];
+                }
+
+                object v = scriptValue;
+                if (elemType != null && TryCoerceTo(scriptValue, elemType, out var cv) && cv != null)
+                    v = cv;
+
+                list[idx] = ScriptNullToClr(v);
+                return true;
+            }
+
+            // IDictionary
+            if (target is IDictionary dict)
+            {
+                object? key = ScriptNullToClr(scriptKey);
+                object? val = ScriptNullToClr(scriptValue);
+
+                var iface = target.GetType().GetInterfaces()
+                    .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+                if (iface != null)
+                {
+                    var ga = iface.GetGenericArguments();
+                    var keyType = ga[0];
+                    var valType = ga[1];
+                    if (key != null && TryCoerceTo(key, keyType, out var ck) && ck != null) key = ck;
+                    if (val != null && TryCoerceTo(val, valType, out var cv) && cv != null) val = cv;
+                }
+
+                try
+                {
+                    dict[key!] = val;
+                    return true;
+                }
+                catch
+                {
+                    // fall through to indexer reflection
+                }
+            }
+
+            // indexer property (Item[...])
+            foreach (var p in t.GetProperties(ClrMemberFlags))
+            {
+                var ip = p.GetIndexParameters();
+                if (ip.Length != 1 || !p.CanWrite)
+                    continue;
+
+                if (!_policy.IsMemberAllowed(p))
+                    continue;
+
+                if (!TryCoerceTo(scriptKey, ip[0].ParameterType, out var ck))
+                    continue;
+
+                object v = scriptValue;
+                if (TryCoerceTo(scriptValue, p.PropertyType, out var cv) && cv != null)
+                    v = cv;
+
+                try
+                {
+                    p.SetValue(target, ScriptNullToClr(v), new object[] { ck });
+                    return true;
+                }
+                catch
+                {
+                    // try next
+                }
+            }
+
+            return false;
+        }
+    
+    }
+}

--- a/Runtime/ClrPolicies.cs
+++ b/Runtime/ClrPolicies.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace ScriptStack.Runtime
+{
+    /// <summary>
+    /// Denies all CLR interop. Default Policy!
+    /// </summary>
+    public sealed class DenyAllClrPolicy : IClrPolicy
+    {
+        public bool IsTypeAllowed(Type t) => false;
+        public bool IsMemberAllowed(MemberInfo m) => false;
+        public bool IsCallAllowed(MethodInfo m) => false;
+        public bool IsReturnValueAllowed(object? value) => false;
+    }
+
+    /// <summary>
+    /// Allows all CLR interop. Use only for trusted scripts.
+    /// </summary>
+    public sealed class AllowAllClrPolicy : IClrPolicy
+    {
+        public bool IsTypeAllowed(Type t) => true;
+        public bool IsMemberAllowed(MemberInfo m) => true;
+        public bool IsCallAllowed(MethodInfo m) => true;
+        public bool IsReturnValueAllowed(object? value) => true;
+    }
+
+    /// <summary>
+    /// A conservative "safe" policy: allows access only to a small set of generally harmless
+    /// BCL types and members, blocks reflection/IO/process/threading by default.
+    /// 
+    /// This is intentionally restrictive. Extend/replace it for your use-case.
+    /// </summary>
+    public sealed class SafeClrPolicy : IClrPolicy
+    {
+        private static bool IsSafePrimitiveLike(Type t)
+        {
+            if (t.IsEnum) return true;
+            if (t.IsPrimitive) return true;
+            if (t == typeof(string)) return true;
+            if (t == typeof(decimal)) return true;
+            if (t == typeof(DateTime)) return true;
+            if (t == typeof(TimeSpan)) return true;
+            if (t == typeof(Guid)) return true;
+            return false;
+        }
+
+        private static bool IsBlockedNamespace(string? ns)
+        {
+            if (string.IsNullOrWhiteSpace(ns)) return false;
+
+            // Hard blocks: high-risk namespaces.
+            return ns.StartsWith("System.IO", StringComparison.Ordinal)
+                || ns.StartsWith("System.Reflection", StringComparison.Ordinal)
+                || ns.StartsWith("System.Diagnostics", StringComparison.Ordinal)
+                || ns.StartsWith("System.Runtime", StringComparison.Ordinal)
+                || ns.StartsWith("System.Threading", StringComparison.Ordinal)
+                || ns.StartsWith("System.Net", StringComparison.Ordinal)
+                || ns.StartsWith("Microsoft.Win32", StringComparison.Ordinal);
+        }
+
+        public bool IsTypeAllowed(Type t)
+        {
+            if (t == null) return false;
+
+            if (IsSafePrimitiveLike(t)) return true;
+
+            if (t.IsArray)
+                return IsTypeAllowed(t.GetElementType()!);
+
+            if (IsBlockedNamespace(t.Namespace))
+                return false;
+
+            // Allow simple collection containers of safe types
+            if (t.IsGenericType)
+            {
+                var def = t.GetGenericTypeDefinition();
+                if (def == typeof(Nullable<>))
+                    return IsTypeAllowed(Nullable.GetUnderlyingType(t)!);
+
+                if (def == typeof(System.Collections.Generic.List<>)
+                    || def == typeof(System.Collections.Generic.IList<>)
+                    || def == typeof(System.Collections.Generic.ICollection<>)
+                    || def == typeof(System.Collections.Generic.IEnumerable<>))
+                {
+                    return IsTypeAllowed(t.GetGenericArguments()[0]);
+                }
+
+                if (def == typeof(System.Collections.Generic.Dictionary<,>)
+                    || def == typeof(System.Collections.Generic.IDictionary<,>))
+                {
+                    var ga = t.GetGenericArguments();
+                    return IsTypeAllowed(ga[0]) && IsTypeAllowed(ga[1]);
+                }
+            }
+
+            // Allow non-generic IList/IDictionary, but only as containers for safe values.
+            if (typeof(System.Collections.IList).IsAssignableFrom(t)) return true;
+            if (typeof(System.Collections.IDictionary).IsAssignableFrom(t)) return true;
+
+            // Everything else: deny.
+            return false;
+        }
+
+        public bool IsMemberAllowed(MemberInfo m)
+        {
+            if (m == null) return false;
+
+            // Block obvious footguns
+            if (m.Name.Equals("GetType", StringComparison.OrdinalIgnoreCase)) return false;
+
+            var declaring = m.DeclaringType;
+            if (declaring == null || !IsTypeAllowed(declaring)) return false;
+
+            if (m is PropertyInfo p)
+            {
+                // Only allow properties that are safe to read/write
+                if (!IsTypeAllowed(p.PropertyType)) return false;
+
+                // Indexer properties are handled by index access; still ensure safe parameter types
+                foreach (var ip in p.GetIndexParameters())
+                {
+                    if (!IsTypeAllowed(ip.ParameterType)) return false;
+                }
+                return true;
+            }
+
+            if (m is FieldInfo f)
+            {
+                // fields: allow only safe types
+                return IsTypeAllowed(f.FieldType);
+            }
+
+            // other member kinds are not allowed here
+            return false;
+        }
+
+        public bool IsCallAllowed(MethodInfo m)
+        {
+            if (m == null) return false;
+
+            var declaring = m.DeclaringType;
+            if (declaring == null || !IsTypeAllowed(declaring)) return false;
+
+            // Block methods that open the door to reflection/unsafe access
+            if (m.Name.Equals("GetType", StringComparison.OrdinalIgnoreCase)) return false;
+            if (m.Name.Equals("GetHashCode", StringComparison.OrdinalIgnoreCase)) return true;
+            if (m.Name.Equals("ToString", StringComparison.OrdinalIgnoreCase)) return true;
+
+            // Only allow calls with safe parameter + return types
+            if (m.ReturnType != typeof(void) && !IsTypeAllowed(m.ReturnType)) return false;
+
+            foreach (var p in m.GetParameters())
+            {
+                if (!IsTypeAllowed(p.ParameterType)) return false;
+            }
+
+            // A small allowlist for common harmless string helpers
+            if (declaring == typeof(string))
+            {
+                string[] allowed =
+                {
+                    "Contains", "StartsWith", "EndsWith", "Substring", "IndexOf", "Replace",
+                    "ToUpper", "ToLower", "Trim", "TrimStart", "TrimEnd", "Split"
+                };
+                return allowed.Contains(m.Name, StringComparer.OrdinalIgnoreCase);
+            }
+
+            // Collections: allow basic operations only (Count is a property, indexers handled separately)
+            if (declaring.IsGenericType && declaring.GetGenericTypeDefinition() == typeof(System.Collections.Generic.List<>))
+            {
+                string[] allowed = { "Add", "Remove", "RemoveAt", "Clear", "Contains" };
+                return allowed.Contains(m.Name, StringComparer.OrdinalIgnoreCase);
+            }
+
+            // Otherwise: deny.
+            return false;
+        }
+
+        public bool IsReturnValueAllowed(object? value)
+        {
+            if (value == null) return true;
+            if (value is NullReference) return true;
+
+            return IsTypeAllowed(value.GetType());
+        }
+    
+    }
+}

--- a/Runtime/IClrPolicy.cs
+++ b/Runtime/IClrPolicy.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Reflection;
+
+namespace ScriptStack.Runtime
+{
+    /// <summary>
+    /// Policy hook for CLR interop. Implementations decide what is accessible from scripts.
+    /// </summary>
+    public interface IClrPolicy
+    {
+        bool IsTypeAllowed(Type t);
+        bool IsMemberAllowed(MemberInfo m);
+        bool IsCallAllowed(MethodInfo m);
+        bool IsReturnValueAllowed(object? value);
+    }
+}

--- a/Runtime/InterpreterOptions.cs
+++ b/Runtime/InterpreterOptions.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace ScriptStack.Runtime
+{
+    public enum ClrInteropMode
+    {
+        Disabled = 0,
+        Safe = 1,
+        Full = 2
+    }
+
+    /// <summary>
+    /// Options for the ScriptStack interpreter.
+    /// 
+    /// Default: CLR interop is disabled (untrusted-by-default).
+    /// </summary>
+    public sealed class InterpreterOptions
+    {
+        public ClrInteropMode Clr { get; set; } = ClrInteropMode.Disabled;
+
+        /// <summary>
+        /// Optional custom CLR policy. If set, it overrides the default policy of the selected <see cref="ClrInteropMode"/>.
+        /// </summary>
+        public IClrPolicy? ClrPolicy { get; set; }
+
+        internal IClrPolicy ResolveClrPolicy()
+        {
+            if (ClrPolicy != null)
+                return ClrPolicy;
+
+            return Clr switch
+            {
+                ClrInteropMode.Full => new AllowAllClrPolicy(),
+                ClrInteropMode.Safe => new SafeClrPolicy(),
+                _ => new DenyAllClrPolicy(),
+            };
+        }
+    }
+}


### PR DESCRIPTION
Die CLR Funktionen wurden in eine eigene Klasse `ClrBridge` ausgelagert. Zusätzlich gibt es ein Interface für CLR Options (erlaubt, eingeschränkt erlaubt, verboten). Die Optionen werden an den Interpreter übergeben, damit mehrere Interpreter verschiedene Policies haben können.

Es gibt die Modi
- Disabled - kein Interop Zugriff
- Full - voller Interop Zugriff
- Safe - Eigene Policy mit `IClrPolicy` erstellen (siehe weiter unten)

```CSharp
var options = new InterpreterOptions { Clr = ClrInteropMode.Full };
Interpreter interpreter = new Interpreter(script, options);
```

Beispiel einer Custom Policy
```CSharp
public sealed class MyClrPolicy : IClrPolicy
{

    private static readonly HashSet<string> AllowedMembers = new(StringComparer.OrdinalIgnoreCase) { "str", "i" };

    private static readonly HashSet<string> AllowedMethods = new(StringComparer.OrdinalIgnoreCase) { "GetString", "GetMember" };

    public bool IsTypeAllowed(Type t)
    {

        // Nur dein Host-Objekt darf als "Target" per Interop verwendet werden
        if (t == typeof(Test))
            return true;

        // Rückgaben/Parameter dürfen primitive "safe" sein
        if (t.IsPrimitive) return true;
        if (t == typeof(string)) return true;
        if (t == typeof(decimal)) return true;

        // Optional: Nullable<T>
        var u = Nullable.GetUnderlyingType(t);
        if (u != null) return IsTypeAllowed(u);

        // Optional: Arrays von safe types
        if (t.IsArray) return IsTypeAllowed(t.GetElementType()!);

        return false;

    }

    public bool IsMemberAllowed(MemberInfo m)
    {
        // Nur Member auf Test zulassen (Felder/Properties)
        if (m.DeclaringType != typeof(Test))
            return false;

        return AllowedMembers.Contains(m.Name);
    }

    public bool IsCallAllowed(MethodInfo m)
    {
        // Nur Methoden auf Test zulassen
        if (m.DeclaringType != typeof(Test))
            return false;

        // Blocke "GetType" 
        if (m.Name.Equals("GetType", StringComparison.OrdinalIgnoreCase))
            return false;

        if (!AllowedMethods.Contains(m.Name))
            return false;

        // Optional: Parameter-Typen einschränke
        foreach (var p in m.GetParameters())
            if (!IsTypeAllowed(p.ParameterType))
                return false;

        return true;
    }

    public bool IsReturnValueAllowed(object? value)
    {
        if (value == null) return true;
        return IsTypeAllowed(value.GetType());
    }

}
```

Policy zuweisen
```CSharp
var options = new InterpreterOptions
{
    ClrPolicy = new MyClrPolicy()
};
Interpreter interpreter = new Interpreter(script, options);
```